### PR TITLE
feat: design upgrades

### DIFF
--- a/src/components/Essay/Essay.js
+++ b/src/components/Essay/Essay.js
@@ -28,7 +28,7 @@ function Essay() {
       )}
       <textarea
         aria-labelledby={'essayHeader'}
-        aria-describedby={essayInstruction ? 'essayInstrucion' : ''}
+        aria-describedby={essayInstruction ? 'essayInstrucion' : undefined}
         ref={essayRef}
         placeholder={translate('essayPlaceholder')}
       />

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -154,10 +154,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   text-overflow: ellipsis;
 
   & > input {
-    background-repeat: no-repeat;
-    padding-left: 1rem;
     border: 1px solid #535c69;
-    background-position: left;
     height: 2rem;
   }
 }

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -155,7 +155,10 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
 
   & > input {
     border: 1px solid #535c69;
+    box-sizing: border-box;
     height: 2rem;
+    min-width: 7rem;
+    max-width: 15rem;
   }
 }
 

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -65,7 +65,6 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
 
   .h5p-keywords-keyword-container {
     width: auto;
-    margin-right: 0.6rem;
   }
 
   .h5p-keywords-keywords-left {
@@ -207,6 +206,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   padding: 0.75rem;
   margin-bottom: 1.1875rem;
   flex-direction: column;
+  gap: 0.6rem;
 }
 
 .h5p-keywords-keyword-container-inner {
@@ -221,7 +221,6 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   border: 2px solid #dbe2e8;
   padding: 0.25rem;
   width: 100%;
-  margin-bottom: 0.6rem;
   box-sizing: border-box;
 }
 

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -175,6 +175,12 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   margin-block-end: 0.83em;
 }
 
+#essayHeader,
+.h5p-keywords-keywordslist-header {
+  font-size: 1.125rem;
+  margin-block-start: 1.5rem;
+}
+
 .h5p-keywords-keyword-button {
   border: 0;
   background-color: transparent;

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -255,16 +255,16 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   & > div {
     border-radius: $borderRadius;
     background-color: rgba(219,226,232,0.25);
-    color: #212121;
+    color: #363636;
     font-weight: bold;
-    font-size: 0.875rem;
-    font-style: italic;
+    font-size: 1rem;
     padding: 0.3125rem 0.625rem;
     align-items: center;
     display: flex;
   }
 
   .fa {
+    color: inherit;
     margin-right: 0.5675rem;
     font-size: 1.5rem;
   }

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -191,7 +191,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   border-radius: 0 5px 5px 0;
 
   &:hover {
-    background-color: rgba(255,0,0,0.05);
+    background-color: rgba(0,0,0,0.05);
   }
 
   .h5p-ri {

--- a/src/components/Keywords.scss
+++ b/src/components/Keywords.scss
@@ -142,7 +142,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
 }
 
 .h5p-keywords-keyword {
-  font-size: 0.8725rem;
+  font-size: 1rem;
   font-weight: 600;
   text-decoration: none solid rgb(18, 18, 18);
   color: #121212;

--- a/src/components/Keywords/Keywords.js
+++ b/src/components/Keywords/Keywords.js
@@ -28,7 +28,8 @@ function Keywords({keyword, onChange, keywordPlaceholder, addKeyword, ariaDelete
     toggleEditMode(false);
   }
 
-  function handleKeyPress(event) {
+  function handleKeyDown(event) {
+    // If enter is pressed
     if (event.which === 13) {
       if (inEditMode) {
         handleBlur(event);
@@ -37,6 +38,7 @@ function Keywords({keyword, onChange, keywordPlaceholder, addKeyword, ariaDelete
         toggleEditMode(true);
       }
     }
+    // If space is pressed
     if (event.which === 32 && !inEditMode) {
       toggleEditMode(true);
     }
@@ -54,7 +56,7 @@ function Keywords({keyword, onChange, keywordPlaceholder, addKeyword, ariaDelete
         >
           <input
             ref={inputRef}
-            onKeyPress={handleKeyPress}
+            onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             onChange={debounce(() => onChange(inputRef.current.value), 100)}
             placeholder={keywordPlaceholder}
@@ -65,7 +67,7 @@ function Keywords({keyword, onChange, keywordPlaceholder, addKeyword, ariaDelete
             'hidden': inEditMode,
           })}
           onClick={() => toggleEditMode(true)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           role={'button'}
           tabIndex={0}
         >

--- a/src/components/Keywords/Keywords.js
+++ b/src/components/Keywords/Keywords.js
@@ -60,6 +60,7 @@ function Keywords({keyword, onChange, keywordPlaceholder, addKeyword, ariaDelete
             onBlur={handleBlur}
             onChange={debounce(() => onChange(inputRef.current.value), 100)}
             placeholder={keywordPlaceholder}
+            size={keyword ? keyword.length : keywordPlaceholder.length}
           />
         </label>
         <div

--- a/src/components/Keywords/Keywords.js
+++ b/src/components/Keywords/Keywords.js
@@ -1,6 +1,5 @@
 import React, {useState, useRef, useEffect} from 'react';
 import PropTypes from 'prop-types';
-import markerIcon from '../../../assets/marker.svg';
 import {debounce} from '../utils';
 import classnames from 'classnames';
 
@@ -59,9 +58,6 @@ function Keywords({keyword, onChange, keywordPlaceholder, addKeyword, ariaDelete
             onBlur={handleBlur}
             onChange={debounce(() => onChange(inputRef.current.value), 100)}
             placeholder={keywordPlaceholder}
-            style={{
-              backgroundImage: 'url(' + markerIcon + ')',
-            }}
           />
         </label>
         <div


### PR DESCRIPTION
- Makes 'add keyword' button more visible. Increases the font-size, removes italic style and changes the font color. 
- Adds more space between keyword and essay sections.
- Increases the font-size of the keyword and essay headline to make it more similar to the other content types, although keeping the font-size below the font-size of the header to make a headline hierarchy. 
- Fixes invalid aria-describedby that occurred whenever there was no introduction added (as it is added to the aria-describedby). 

Other:
- Changes the color of the hover effect on the keyword button. Used to be pink and not so visible against the background. Now it only add a darker color and keeps the color hue. 
- Uses flex gap instead of margin to separate the keywords in the container. This makes the spacing equal on all edges. 
- Increases the font-size of the keywords (from 14px to 16px). 
- Removes background-image from keyword input.
- Changes deprecated onKeyPress to onKeyDown.
- Make the input fields width follow the text content better by using size attribute. Maximum and minimum size is handled with css to make sure the input field is not bigger than the keyword container.